### PR TITLE
added main to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-twemoji",
   "version": "0.0.7",
+  "main": "dist/angular-twemoji.min.js",
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
Adding "main" to the bower.json file will allow this library to be used with [grunt-wiredep](https://github.com/stephenplusplus/grunt-wiredep)
